### PR TITLE
Add permission bypass as config option

### DIFF
--- a/src/main/java/tc/oc/occ/idly/IdlyConfig.java
+++ b/src/main/java/tc/oc/occ/idly/IdlyConfig.java
@@ -12,6 +12,7 @@ public class IdlyConfig {
   private int observerDelay;
   private int warningDuration;
   private int warningFrequency;
+  private boolean bypassEnabled;
   private boolean requireMatchRunning;
   private boolean preciseMovement;
   private boolean movementCheck;
@@ -46,6 +47,10 @@ public class IdlyConfig {
     return warningFrequency;
   }
 
+  public boolean isBypassEnabled() {
+    return bypassEnabled;
+  }
+
   public boolean isRequireMatchRunning() {
     return requireMatchRunning;
   }
@@ -73,6 +78,7 @@ public class IdlyConfig {
     this.observerDelay = config.getInt("observer-delay");
     this.warningDuration = config.getInt("warning-duration");
     this.warningFrequency = config.getInt("warning-frequency");
+    this.bypassEnabled = config.getBoolean("bypass-enabled", true);
     this.requireMatchRunning = config.getBoolean("require-match-running");
     this.preciseMovement = config.getBoolean("precise-movement");
     this.movementCheck = config.getBoolean("checks.movement");

--- a/src/main/java/tc/oc/occ/idly/IdlyManager.java
+++ b/src/main/java/tc/oc/occ/idly/IdlyManager.java
@@ -58,7 +58,7 @@ public class IdlyManager {
     if (!config.isKickMode() && !isPlaying) return;
 
     // Ignore those with the bypass permission
-    if (player.hasPermission(IdlyPermissions.BYPASS)) return;
+    if (config.isBypassEnabled() && player.hasPermission(IdlyPermissions.BYPASS)) return;
 
     int duration = (isPlaying ? config.getParticipantDelay() : config.getObserverDelay());
     float remaining = duration - inactivity;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,7 +17,10 @@ observer-delay: 120
 warning-duration: 15
 
 # Frequency between warning countdown messages (in seconds)
-warning-frequency: 5 
+warning-frequency: 5
+
+# Allow player bypass with 'idly.bypass' permission
+bypass-enabled: true
 
 # Only check for inactivity when match is running
 require-match-running: true


### PR DESCRIPTION
Allows you to disable the permission bypass check. Useful in instances where an OPed player may need kicking.

Signed-off-by: Pugzy <pugzy@mail.com>