### PR TITLE
Update isPlaying check to include match state

### DIFF
--- a/src/main/java/tc/oc/occ/idly/api/BaseIdlyAPI.java
+++ b/src/main/java/tc/oc/occ/idly/api/BaseIdlyAPI.java
@@ -2,6 +2,7 @@ package tc.oc.occ.idly.api;
 
 import org.bukkit.entity.Player;
 import tc.oc.occ.idly.IdlyUtils;
+import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 public class BaseIdlyAPI implements IdlyAPI {
@@ -15,6 +16,6 @@ public class BaseIdlyAPI implements IdlyAPI {
   @Override
   public boolean isPlaying(Player player) {
     MatchPlayer mp = IdlyUtils.getMatchPlayer(player);
-    return mp != null && mp.isParticipating();
+    return mp != null && mp.getParty() instanceof Competitor && !mp.getMatch().isFinished();
   }
 }


### PR DESCRIPTION
Currently `isPlaying` is only checked when `require-match-running` is set to `false` via a config option. The check for if a player is playing uses `isParticipating` this is `false` if the match isn't running but they are on a team.

This change requires the user to be on a team and for the match not to have ended to consider them true as `isPlaying`. This allows players who have joined a team prior to the match starting (countdown) to be included as a "player" but also allows them to be excluded once the match has ended.

Signed-off-by: Pugzy <pugzy@mail.com>