### PR TITLE
Use UUID based map adapter and tweak logic

### DIFF
--- a/src/main/java/tc/oc/occ/idly/IdlyConfig.java
+++ b/src/main/java/tc/oc/occ/idly/IdlyConfig.java
@@ -14,7 +14,6 @@ public class IdlyConfig {
   private int warningDuration;
   private int warningFrequency;
   private boolean bypassEnabled;
-  private boolean requireMatchRunning;
   private boolean preciseMovement;
   private boolean movementCheck;
   private boolean chatCheck;
@@ -59,10 +58,6 @@ public class IdlyConfig {
 
   public boolean isBypassEnabled() {
     return bypassEnabled;
-  }
-
-  public boolean isRequireMatchRunning() {
-    return requireMatchRunning;
   }
 
   public boolean isPreciseMovement() {
@@ -110,7 +105,6 @@ public class IdlyConfig {
     this.warningDuration = config.getInt("warning-duration");
     this.warningFrequency = config.getInt("warning-frequency");
     this.bypassEnabled = config.getBoolean("bypass-enabled", true);
-    this.requireMatchRunning = config.getBoolean("require-match-running");
     this.preciseMovement = config.getBoolean("precise-movement");
     this.movementCheck = config.getBoolean("checks.movement");
     this.chatCheck = config.getBoolean("checks.chat");

--- a/src/main/java/tc/oc/occ/idly/IdlyListener.java
+++ b/src/main/java/tc/oc/occ/idly/IdlyListener.java
@@ -7,7 +7,8 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
-import tc.oc.pgm.api.match.event.MatchStartEvent;
+import tc.oc.pgm.api.match.MatchPhase;
+import tc.oc.pgm.api.match.event.MatchPhaseChangeEvent;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 
@@ -34,8 +35,11 @@ public class IdlyListener implements Listener {
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
-  public void onMatchStart(MatchStartEvent event) {
-    event.getMatch().getParticipants().forEach(p -> this.manager.logMovement(p.getBukkit()));
+  public void onMatchStart(MatchPhaseChangeEvent event) {
+    // Log participant activity when match starts (to avoid instant kicking)
+    if (event.getOldPhase() == MatchPhase.IDLE && event.getNewPhase() != MatchPhase.IDLE) {
+      event.getMatch().getParticipants().forEach(p -> this.manager.logMovement(p.getBukkit()));
+    }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/tc/oc/occ/idly/api/BaseIdlyAPI.java
+++ b/src/main/java/tc/oc/occ/idly/api/BaseIdlyAPI.java
@@ -2,20 +2,17 @@ package tc.oc.occ.idly.api;
 
 import org.bukkit.entity.Player;
 import tc.oc.occ.idly.IdlyUtils;
+import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 public class BaseIdlyAPI implements IdlyAPI {
 
   @Override
-  public boolean isMatchRunning(Player player) {
-    MatchPlayer mp = IdlyUtils.getMatchPlayer(player);
-    return mp != null && mp.getMatch().isRunning();
-  }
-
-  @Override
   public boolean isPlaying(Player player) {
     MatchPlayer mp = IdlyUtils.getMatchPlayer(player);
-    return mp != null && mp.getParty() instanceof Competitor && !mp.getMatch().isFinished();
+    return mp != null
+        && mp.getParty() instanceof Competitor
+        && (mp.getMatch().getPhase().equals(MatchPhase.STARTING) || mp.getMatch().isRunning());
   }
 }

--- a/src/main/java/tc/oc/occ/idly/api/IdlyAPI.java
+++ b/src/main/java/tc/oc/occ/idly/api/IdlyAPI.java
@@ -4,7 +4,5 @@ import org.bukkit.entity.Player;
 
 public interface IdlyAPI {
 
-  boolean isMatchRunning(Player player);
-
   boolean isPlaying(Player player);
 }

--- a/src/main/java/tc/oc/occ/idly/utils/OnlinePlayerUUIDMapAdapter.java
+++ b/src/main/java/tc/oc/occ/idly/utils/OnlinePlayerUUIDMapAdapter.java
@@ -1,0 +1,33 @@
+package tc.oc.occ.idly.utils;
+
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
+import tc.oc.pgm.util.bukkit.ListeningMapAdapter;
+
+public class OnlinePlayerUUIDMapAdapter<V> extends ListeningMapAdapter<UUID, V>
+    implements Listener {
+  public OnlinePlayerUUIDMapAdapter(Plugin plugin) {
+    super(plugin);
+  }
+
+  public OnlinePlayerUUIDMapAdapter(Map<UUID, V> map, Plugin plugin) {
+    super(map, plugin);
+  }
+
+  public boolean isValid(UUID key) {
+    Player player = Bukkit.getPlayer(key);
+    return player != null && player.isOnline();
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPlayerQuit(PlayerQuitEvent event) {
+    this.remove(event.getPlayer().getUniqueId());
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,9 +25,6 @@ warning-frequency: 5
 # Allow player bypass with 'idly.bypass' permission
 bypass-enabled: true
 
-# Only check for inactivity when match is running
-require-match-running: true
-
 # When true movement is tracked on pitch/yaw movement only
 precise-movement: true
 


### PR DESCRIPTION
A few tweaks to fingers crossed fix some bugs and simplify the logic.

- Switch to storing UUIDs of online players rather than player entities.
- Remove `require-match-running` config option and logic.
- Count a user as playing if they're on a team and the match is starting or running.
- Reset participant activity log when state changes from idle (to account for above).