### PR TITLE
Iterate on copy of inactive ticks map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,23 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <!-- Exposes git information to the build environment -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.9.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/tc/oc/occ/idly/IdlyManager.java
+++ b/src/main/java/tc/oc/occ/idly/IdlyManager.java
@@ -5,6 +5,7 @@ import static net.kyori.adventure.sound.Sound.sound;
 import static net.kyori.adventure.text.Component.text;
 
 import com.google.common.base.Objects;
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import net.kyori.adventure.audience.Audience;
@@ -54,8 +55,8 @@ public class IdlyManager {
   private void checkPlayers() {
     if (!config.isEnabled()) return;
 
-    for (UUID uuid : this.playerInactivityTicks.keySet()) {
-      Player player = Bukkit.getPlayer(uuid);
+    for (Map.Entry<UUID, Integer> entry : this.playerInactivityTicks.entrySetCopy()) {
+      Player player = Bukkit.getPlayer(entry.getKey());
       if (player == null || !player.isOnline()) continue;
       checkPlayer(player);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ${project.name}
 description: ${project.description}
 main: ${project.bukkit.main}
-version: ${project.version}
+version: ${project.version} (git-${git.commit.id.abbrev})
 author: ${project.author}
 depend: [PGM]


### PR DESCRIPTION
The current implementation causes exceptions when trying to modify playerInactivityTicks inside the loop.

This commit also adds auto versioning using the git version in the plugin.yml.

Not sure if anything extra needs importing for the above to work (that I don't have .m2 cached) but I guess we will see once merged.